### PR TITLE
web_editor_html can sometimes be None due to surroundContents() faili…

### DIFF
--- a/codehighlighter/ankieditorextra.py
+++ b/codehighlighter/ankieditorextra.py
@@ -36,6 +36,7 @@ def extract_field_from_web_editor(web_editor_html: str) -> Optional[str]:
       containing the editing widget.
     :rtype Optional[str]: On a failure to find the field, returns None.
     """
+    web_editor_html = web_editor_html or ""
     result = re.search('<anki-editable[^>]*>(.*)</anki-editable>',
                        web_editor_html, re.MULTILINE | re.DOTALL)
     if result is None:


### PR DESCRIPTION
There are cases where surroundContents() will fail. In this case, `web_editor_html` will be `None`, and then the regular expression search will throw an exception:

```
JS error /_anki/legacyPageData?id=5842112864:9 Uncaught InvalidStateError: Failed to execute 'surroundContents' on 'Range': The Range has partially selected a non-Text node.
Caught exception:
Traceback (most recent call last):
  File "aqt.webview", line 562, in handler
  File "/Users/dhiren/Library/Application Support/Anki2/addons21/112228974/ankieditorextra.py", line 77, in transform_field
    field = extract_field_from_web_editor(web_editor_html)
  File "/Users/dhiren/Library/Application Support/Anki2/addons21/112228974/ankieditorextra.py", line 40, in extract_field_from_web_editor
    result = re.search('<anki-editable[^>]*>(.*)</anki-editable>',
  File "re", line 201, in search
TypeError: expected string or bytes-like object
```

This minor patch makes it fail silently so you don't get the exception.