### PR TITLE
fix: ignore MarkupResemblesLocatorWarning

### DIFF
--- a/codehighlighter/ankieditorextra.py
+++ b/codehighlighter/ankieditorextra.py
@@ -10,7 +10,7 @@ import aqt  # type: ignore
 import bs4  # type: ignore
 from bs4 import BeautifulSoup, NavigableString
 
-from .bs4extra import encode_soup
+from .bs4extra import create_soup, encode_soup
 
 __all__ = ['extract_field_from_web_editor', 'transform_selection']
 
@@ -20,7 +20,7 @@ def transform_elements_with_id(html: str, id: str,
                                replace: Callable[[str],
                                                  Union[bs4.Tag,
                                                        bs4.BeautifulSoup]]):
-    soup = BeautifulSoup(html, features='html.parser')
+    soup = create_soup(html)
     for element in soup.find_all(id=id):
         element.replace_with(replace(element.decode_contents()))
     return encode_soup(soup)
@@ -110,8 +110,7 @@ def transform_selection(editor: aqt.editor.Editor, note: anki.notes.Note,
         def format(code: str) -> Union[bs4.Tag, bs4.BeautifulSoup]:
             # If the provided transform has failed, use an effect-less
             # transform to clean up annotations.
-            return (transform(code)
-                    or bs4.BeautifulSoup(code, features='html.parser'))
+            return transform(code) or create_soup(code)
 
         note.fields[currentField] = transform_elements_with_id(
             field, random_id, format)

--- a/codehighlighter/bs4extra.py
+++ b/codehighlighter/bs4extra.py
@@ -1,14 +1,27 @@
 # -*- coding: utf-8 -*-
 """ Extra functions extending BeautifulSoup."""
 from typing import Union
+import warnings
+
 import bs4
 from bs4 import BeautifulSoup
 
 import re
 
 __all__ = [
+    'create_soup',
     'encode_soup',
 ]
+
+
+def create_soup(html: str) -> bs4.BeautifulSoup:
+    """Creates a BeautifulSoup from HTML code."""
+    # Using html.parser, because it should be bundled in all Python
+    # environments.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore",
+                              category=bs4.MarkupResemblesLocatorWarning)
+        return BeautifulSoup(html, features='html.parser')
 
 
 def encode_soup(tag: Union[bs4.Tag, bs4.BeautifulSoup]) -> str:
@@ -28,7 +41,7 @@ def replace_br_tags_with_newlines(html: str) -> str:
     :param node str: HTML code
     :rtype str: Reformatted HTML code
     """
-    soup = BeautifulSoup(html, features='html.parser')
+    soup = create_soup(html)
     for br in soup.find_all('br'):
         br.replace_with('\n')
     new_html = encode_soup(soup)

--- a/codehighlighter/highlighter.py
+++ b/codehighlighter/highlighter.py
@@ -7,7 +7,7 @@ from typing import List
 
 import bs4  # type: ignore
 from bs4 import BeautifulSoup, NavigableString
-from .bs4extra import replace_br_tags_with_newlines
+from .bs4extra import create_soup, replace_br_tags_with_newlines
 
 import os, sys
 
@@ -72,7 +72,7 @@ def format_code_hljs(
     Returns:
         A BeautifulSoup tag.
     """
-    soup = BeautifulSoup(code, features='html.parser')
+    soup = create_soup(code)
     code_tag = soup.new_tag('code')
     if language == 'nohighlight':
         code_tag['class'] = [language]
@@ -140,4 +140,4 @@ def format_code_pygments(
     if display_style is DISPLAY_STYLE.INLINE:
         highlighted = remove_spurious_inline_newline(highlighted)
 
-    return BeautifulSoup(highlighted, features='html.parser')
+    return create_soup(highlighted)

--- a/test/test_highlighter.py
+++ b/test/test_highlighter.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
+import textwrap
 import unittest
+import warnings
 
 from codehighlighter.bs4extra import encode_soup
 from codehighlighter.highlighter import format_code_hljs
@@ -24,3 +26,21 @@ class FormatCodeTestCase(unittest.TestCase):
             "  return 0</div></code></pre>")
         output_html = encode_soup(format_code_hljs('python', code_snippet))
         self.assertEqual(output_html, expected_html)
+
+    def test_hljs_formatting_doesnt_throw_warnings(self):
+        """https://github.com/gregorias/anki-code-highlighter/issues/37"""
+        code_snippet = """\
+                       template
+                       void f(T&amp;&amp; arg) {}
+
+                       void main() {
+                         vector v;
+                         const vector cv;
+                         f(v);            // 1
+                         f(cv);           // 2
+                         f(std::move(v)); // 3
+                       }"""
+        code_snippet = textwrap.dedent(code_snippet)
+        with warnings.catch_warnings(record=True) as caught_warnings:
+            format_code_hljs('cpp', code_snippet)
+            self.assertListEqual(caught_warnings, [])


### PR DESCRIPTION
This warning warns the user that their text resembles URL. I don't think it's useful to show this potentially noisy error.

Fixes #37.