### PR TITLE
docs: update guide on using `generatepygmentscss`

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,9 +130,9 @@ To add a custom style, do the following:
 
 ### Generating a stylesheet for pygments
 
-1. Modify `XXX_STYLE` variables in `dev/bin/generate-pygments-css` to use your
+1. Modify `XXX_STYLE` variables in `tools/generatepygmentscss.py` to use your
    desired style for each mode.
-1. To generate a ready to use stylesheet, run `dev/bin/generate-pygments-css`.
+1. To generate a ready to use stylesheet, run `python -m tools.generatepygmentscss`.
    You may need to install a few dependencies for that script to run
    (`pygments`, `webcolors`). Import errors will guide you.
 


### PR DESCRIPTION
Hello! Hope you're doing well.

Thank you for maintaining this plugin. It's been very instrumental in using Anki for programming related content.

I was trying to generate a custom style and found the README.md was probably pointing to the outdated `dev/bin/generate-pygments-css`, hence this very small change.

Thank you again!
